### PR TITLE
Set continue-on-error to false for install step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,8 @@ jobs:
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
-
+        continue-on-error: false
+        
       - name: Build
         run: pnpm build
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set the GitHub Actions install-dependencies step to not continue on error, causing the workflow to fail if dependency installation fails.